### PR TITLE
Add the operation 0x0C to draw rounded rectangles with varying radii

### DIFF
--- a/c_src/device/nvg/nvg_script_ops.c
+++ b/c_src/device/nvg/nvg_script_ops.c
@@ -106,6 +106,27 @@ void script_ops_draw_rrect(void* v_ctx,
   if (stroke) nvgStroke(p_ctx);
 }
 
+void script_ops_draw_rrectv(void* v_ctx,
+                           float w,
+                           float h,
+                           float ulr,
+                           float urr,
+                           float lrr,
+                           float llr,
+                           bool fill, bool stroke)
+{
+  if (g_opts.debug_mode) {
+    log_script_ops_draw_rrectv(log_prefix, __func__, log_level_info,
+                               w, h, ulr, urr, lrr, llr, fill, stroke);
+  }
+
+  NVGcontext* p_ctx = (NVGcontext*)v_ctx;
+  nvgBeginPath(p_ctx);
+  nvgRoundedRectVarying(p_ctx, 0, 0, w, h, ulr, urr, lrr, llr);
+  if (fill) nvgFill(p_ctx);
+  if (stroke) nvgStroke(p_ctx);
+}
+
 void script_ops_draw_arc(void* v_ctx,
                          float radius,
                          float radians,

--- a/c_src/scenic/script.c
+++ b/c_src/scenic/script.c
@@ -255,6 +255,18 @@ void render_script(void* v_ctx, sid_t id)
         }
         i += 12;
         break;
+      case SCRIPT_OP_DRAW_RRECTV:
+        {
+          float w = get_float(p, i);
+          float h = get_float(p, i + 4);
+          float ulr = get_float(p, i + 8);
+          float urr = get_float(p, i + 12);
+          float lrr = get_float(p, i + 16);
+          float llr = get_float(p, i + 20);
+          script_ops_draw_rrectv(v_ctx, w, h, ulr, urr, lrr, llr, (param & FLAG_FILL), (param & FLAG_STROKE));
+        }
+        i += 24;
+        break;
       case SCRIPT_OP_DRAW_ARC:
         {
           float radius = get_float(p, i);

--- a/c_src/scenic/script_ops.c
+++ b/c_src/scenic/script_ops.c
@@ -113,6 +113,34 @@ void log_script_ops_draw_rrect(const char* prefix, const char* func, log_level_t
 }
 
 __attribute__((weak))
+void script_ops_draw_rrectv(void *v_ctx, float w, float h, float ulr, float urr, float lrr, float llr, bool fill, bool stroke)
+{
+  log_script_ops_draw_rrectv(log_prefix, __func__, log_level_warn, w, h, ulr, urr, lrr, llr, fill, stroke);
+}
+void log_script_ops_draw_rrectv(const char *prefix, const char *func, log_level_t level, float w, float h, float ulr, float urr, float lrr, float llr, bool fill, bool stroke)
+{
+  log_message(level, "%s %s: %{"
+              "w: %.1f, "
+              "h: %.1f, "
+              "ulr: %.1f, "
+              "urr: %.1f, "
+              "lrr: %.1f, "
+              "llr: %.1f, "
+              "fill: %s, "
+              "stroke: %s"
+              "}",
+              prefix, func,
+              w,
+              h,
+              ulr,
+              urr,
+              lrr,
+              llr,
+              (fill) ? "true" : "false",
+              (stroke) ? "true" : "false");
+}
+
+__attribute__((weak))
 void script_ops_draw_arc(void* v_ctx, float radius, float radians, bool fill, bool stroke)
 {
   log_script_ops_draw_arc(log_prefix, __func__, log_level_warn, radius, radians, fill, stroke);
@@ -795,6 +823,7 @@ const char* script_op_to_string(script_op_t op)
   case SCRIPT_OP_DRAW_QUAD: return "script_op_draw_quad";
   case SCRIPT_OP_DRAW_RECT: return "script_op_draw_rect";
   case SCRIPT_OP_DRAW_RRECT: return "script_op_draw_rrect";
+  case SCRIPT_OP_DRAW_RRECTV: return "script_op_draw_rrectv";
   case SCRIPT_OP_DRAW_ARC: return "script_op_draw_arc";
   case SCRIPT_OP_DRAW_SECTOR: return "script_op_draw_sector";
   case SCRIPT_OP_DRAW_CIRCLE: return "script_op_draw_circle";

--- a/c_src/scenic/script_ops.h
+++ b/c_src/scenic/script_ops.h
@@ -14,6 +14,7 @@ typedef enum {
   SCRIPT_OP_DRAW_ELLIPSE = 0X09,
   SCRIPT_OP_DRAW_TEXT = 0X0A,
   SCRIPT_OP_DRAW_SPRITES = 0X0B,
+  SCRIPT_OP_DRAW_RRECTV = 0X0C,
   SCRIPT_OP_DRAW_SCRIPT = 0X0F,
 
   SCRIPT_OP_BEGIN_PATH = 0X20,
@@ -137,6 +138,7 @@ SCRIPT_FUNC(draw_triangle, coordinates_t a, coordinates_t b, coordinates_t c, bo
 SCRIPT_FUNC(draw_quad, coordinates_t a, coordinates_t b, coordinates_t c, coordinates_t d, bool fill, bool stroke);
 SCRIPT_FUNC(draw_rect, float w, float h, bool fill, bool stroke);
 SCRIPT_FUNC(draw_rrect, float w, float h, float radius, bool fill, bool stroke);
+SCRIPT_FUNC(draw_rrectv, float w, float h, float ulr, float urr, float lrr, float llr, bool fill, bool stroke);
 SCRIPT_FUNC(draw_arc, float radius, float radians, bool fill, bool stroke);
 SCRIPT_FUNC(draw_sector, float radius, float radians, bool fill, bool stroke);
 SCRIPT_FUNC(draw_circle, float radius, bool fill, bool stroke);


### PR DESCRIPTION
This PR adds the operation 0x0C to draw rounded rectangle with variable radius corners, using the already existing functionality on NanoVG.
This operation will be used on `Scenic.Script.draw_rounded_rectangle` as described by [rounded rectangle canvas specs](https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-roundrect).

Result:
<img width="256" alt="Screen Shot 2022-09-08 at 14 26 52" src="https://user-images.githubusercontent.com/4721118/189262170-c12451e3-2c60-443f-83c6-ba03e7a78bc3.png">

Left: green filled rectangle with corner radius: 25, 50, 75, 100
Right: empty rectangle with purple stroke with corner radius: 100, 75, 50, 25