### PR TITLE
Fix incorrect font width calculation in fontstash

### DIFF
--- a/c_src/nanovg/fontstash.h
+++ b/c_src/nanovg/fontstash.h
@@ -383,7 +383,8 @@ struct FONSglyph
 	int next;
 	short size, blur;
 	short x0,y0,x1,y1;
-	short xadv,xoff,yoff;
+	short xoff,yoff;
+	float xadv;
 };
 typedef struct FONSglyph FONSglyph;
 
@@ -1155,7 +1156,7 @@ static FONSglyph* fons__getGlyph(FONScontext* stash, FONSfont* font, unsigned in
 	glyph->y0 = (short)gy;
 	glyph->x1 = (short)(glyph->x0+gw);
 	glyph->y1 = (short)(glyph->y0+gh);
-	glyph->xadv = (short)(scale * advance * 10.0f);
+	glyph->xadv = scale * advance * 10.0f;
 	glyph->xoff = (short)(x0 - pad);
 	glyph->yoff = (short)(y0 - pad);
 

--- a/c_src/nanovg/fontstash.h
+++ b/c_src/nanovg/fontstash.h
@@ -1211,7 +1211,7 @@ static void fons__getQuad(FONScontext* stash, FONSfont* font,
 
 	if (prevGlyphIndex != -1) {
 		float adv = fons__tt_getGlyphKernAdvance(&font->font, prevGlyphIndex, glyph->index) * scale;
-		*x += (int)(adv + spacing + 0.5f);
+		*x += (adv + spacing);
 	}
 
 	// Each glyph has 2px border to allow good interpolation,
@@ -1252,7 +1252,7 @@ static void fons__getQuad(FONScontext* stash, FONSfont* font,
 		q->t1 = y1 * stash->ith;
 	}
 
-	*x += (int)(glyph->xadv / 10.0f + 0.5f);
+	*x += (glyph->xadv / 10.0f);
 }
 
 static void fons__flush(FONScontext* stash)

--- a/c_src/script.c
+++ b/c_src/script.c
@@ -213,7 +213,8 @@ void render_text( char* p_text, unsigned int size, NVGcontext* p_ctx )
   int        nrows, i;
 
   // up to this code to break the lines...
-  while ((nrows = nvgTextBreakLines(p_ctx, start, end, 1000, rows, 3)))
+  int breakRowWidth = 10000;
+  while ((nrows = nvgTextBreakLines(p_ctx, start, end, breakRowWidth, rows, 3)))
   {
     for (i = 0; i < nrows; i++)
     {

--- a/c_src/script.c
+++ b/c_src/script.c
@@ -213,8 +213,7 @@ void render_text( char* p_text, unsigned int size, NVGcontext* p_ctx )
   int        nrows, i;
 
   // up to this code to break the lines...
-  int breakRowWidth = 10000;
-  while ((nrows = nvgTextBreakLines(p_ctx, start, end, breakRowWidth, rows, 3)))
+  while ((nrows = nvgTextBreakLines(p_ctx, start, end, 1000, rows, 3)))
   {
     for (i = 0; i < nrows; i++)
     {


### PR DESCRIPTION
This PR is probably not ready to merge, but I'm sharing it here to make the information public for anyone else facing text-alignment issues...

This PR has 2 main changes.

1) I changed `breakRowWidth` from 1000 to 10000, just to bypass the line-wrap that occurs on long lines
2) I removed the logic inside `fontstash.h` which rounds the glyph width of each character to the nearest integer, to be more accurate with what the FontMetrics package (and the canvas implementation, based on your testing as we discussed in Slack) gives us. It isn't perfect, there's still some inaccuracies, but it's "good enough" for my personal projects (QuillEx & Flamelex). It seems perfect for monospaced fonts with no spacing, but some other fonts e.g. Roboto-Regular and fira-code (which is actually monospaced, but maybe has extra spacing between letters??) it's still a tiny bit off.