### PR TITLE
KMS update for RPI4 support

### DIFF
--- a/c_src/device/drm.c
+++ b/c_src/device/drm.c
@@ -54,7 +54,7 @@ static void page_flip_handler(int fd, unsigned int frame,
 uint8_t DISP_ID = 0;
 uint8_t all_display = 0;
 int8_t connector_id = -1;
-char* device = "/dev/dri/card0";
+char* device = "/dev/dri/card1";
 
 fd_set fds;
 drmEventContext evctx = {


### PR DESCRIPTION
This is the matching scenic_driver_local change for: https://github.com/nerves-project/nerves_system_rpi4/pull/155

The instructions there were "Edit ./deps/scenic_driver_local/c_src/device/drm.c and change /dev/dri/card0 to /dev/dri/card1"

This may or may not be good to merge as-is. I mainly wanted to put it up as an example and to facilitate testing. Maybe the card number/device should be passed through from Elixir instead of hard-coded.