### PR TITLE
use DISPMANX_FLAGS_ALPHA_FROM_SOURCE to allow finer control of the op…

### DIFF
--- a/c_src/device/bcm.c
+++ b/c_src/device/bcm.c
@@ -157,7 +157,7 @@ int device_init( const device_opts_t* p_opts, device_info_t* p_info ) {
   // create the screen element (will be full-screen)
   VC_DISPMANX_ALPHA_T alpha =
   {
-      DISPMANX_FLAGS_ALPHA_FIXED_ALL_PIXELS,
+      DISPMANX_FLAGS_ALPHA_FROM_SOURCE,
       p_opts->global_opacity, /*alpha 0->255*/
       0
   };


### PR DESCRIPTION
The change allow to precisely control the opacity of scenic elements when combined with a :clear background. It is specially useful to have scenic overlays that shows on top of for instance an underlying video displayed with omxplayer.