### PR TITLE
fix resize support for glfw

### DIFF
--- a/c_src/device/glfw.c
+++ b/c_src/device/glfw.c
@@ -239,9 +239,7 @@ int device_init( const device_opts_t* p_opts, device_info_t* p_info ) {
   glfwSetErrorCallback(errorcb);
 
   // set the glfw window hints - done before window creation
-  set_window_hints(
-    true           // resizable?
-  );
+  set_window_hints(p_opts->resizable);
 
   // Create a windowed mode window and its OpenGL context
   g_glfw_data.p_window = glfwCreateWindow(


### PR DESCRIPTION
Not sure if it was intentional or just missed, but the `glfw` driver hard-coded windows as being always resizable.  This PR changes it to use the `resizable` option that was passed in.

To reproduce:
1. Create the basic app using `scenic.new`.
2. Validate that it has a default of `resizable: false` in `config/config.exs`
3. Start app with `mix scenic.run`.
4. Attempt to resize the window.

Tested and works on my Mac.