### PR TITLE
Add input_blacklist opts to remove unwanted InputEvent streams

### DIFF
--- a/lib/driver.ex
+++ b/lib/driver.ex
@@ -39,7 +39,8 @@ defmodule Scenic.Driver.Local do
       type:
         {:or, [:mfa, {:in, [:restart, :stop_driver, :stop_viewport, :stop_system, :halt_system]}]},
       default: :restart
-    ]
+    ],
+    input_blacklist: [type: {:list, :string}, default: []]
   ]
 
   # @mix_target Mix.Tasks.Compile.ScenicDriverLocal.target()
@@ -262,7 +263,8 @@ defmodule Scenic.Driver.Local do
         cursor_update: false,
         rel_x: 0,
         rel_y: 0,
-        dirty_streams: []
+        dirty_streams: [],
+        input_blacklist: opts[:input_blacklist]
       )
 
     # send message to set up the cursor later

--- a/lib/input.ex
+++ b/lib/input.ex
@@ -44,6 +44,9 @@ defmodule Scenic.Driver.Local.Input do
 
     input_state =
       inputs
+      |> Enum.reject(fn {_, info} ->
+        Enum.find(driver.assigns.input_blacklist, &(&1 == info.name))
+      end)
       |> Enum.reduce(%{}, fn {path, info}, acc ->
         {:ok, pid} = InputEvent.start_link(path)
 


### PR DESCRIPTION
I'm using [tslib](https://github.com/libts/tslib) to create a /dev/input stream that normalizes an input stream that produces just raw adc values to one that produces screen coordinates. This results in two event devices in `/dev/input/`:
```
iex(3)> cmd "ts_uinput -d -v"

20:08:03.267 [info] input: ts_uinput as /devices/virtual/input/input1
/dev/input/event1
0
iex(4)> InputEvent.enumerate
[
  {"/dev/input/event0",
   %InputEvent.Info{
     input_event_version: "1.0.1",
     name: "resistive-adc-touch",
     bus: 25,
     vendor: 0,
     product: 0,
     version: 0,
     report_info: [
       ev_abs: [
         abs_x: %{flat: 0, fuzz: 0, max: 4094, min: 0, resolution: 0, value: 0},
         abs_y: %{flat: 0, fuzz: 0, max: 4094, min: 0, resolution: 0, value: 0},
         abs_pressure: %{
           flat: 0,
           fuzz: 0,
           max: 65535,
           min: 50000,
           resolution: 0,
           value: 0
         }
       ],
       ev_key: [:btn_touch]
     ]
   }},
  {"/dev/input/event1",
   %InputEvent.Info{
     input_event_version: "1.0.1",
     name: "ts_uinput",
     bus: 6,
     vendor: 0,
     product: 0,
     version: 0,
     report_info: [
       ev_abs: [
         abs_x: %{flat: 0, fuzz: 0, max: 479, min: 0, resolution: 0, value: 0},
         abs_y: %{flat: 0, fuzz: 0, max: 271, min: 0, resolution: 0, value: 0},
         abs_pressure: %{
           flat: 0,
           fuzz: 0,
           max: 65535,
           min: 50000,
           resolution: 0,
           value: 0
         }
       ],
       ev_key: [:btn_touch]
     ]
   }}
]
```
The `init_input` function will add both of them and this causes double events to be sent to the scene.
This PR adds a `input_blacklist` option to remove unwanted InputEvent GenServers from being created.
