### PR TITLE
Fix failing build on macOS

### DIFF
--- a/c_src/device/gl_helpers.c
+++ b/c_src/device/gl_helpers.c
@@ -3,7 +3,11 @@
 #ifdef SCENIC_GLES2
   #include <GLES3/gl2.h>
 #else
-  #include <GLES3/gl3.h>
+  #ifdef __APPLE__
+    #include <OpenGL/gl3.h>
+  #else
+    #include <GLES3/gl3.h>
+  #endif
 #endif
 
 #include "comms.h"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

Include OpenGL/gl3.h on macOS in `c_src/defvice/gl_helpers.c`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm building the latest head of main on macOS Ventura, and ran into a classic macOS OpenGL header issue: `fatal error: 'GLES3/gl3.h' file not found`.

It appears this issue was introduced in https://github.com/ScenicFramework/scenic_driver_local/commit/51f91bf17d0ccec250508b6558efb909e96d1c87

The codebase is already using the `__APPLE__` cpp directive for conditional includes in `c_src/nanovg/nanovg_gl_utils.h` for similar reasons.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.