### PR TITLE
Adds new operation 'arc' to draw arcs on current path.

### DIFF
--- a/c_src/scenic/ops/nvg_script_ops.c
+++ b/c_src/scenic/ops/nvg_script_ops.c
@@ -228,7 +228,7 @@ static void draw_image(void* v_ctx,
   NVGcontext* p_ctx = (NVGcontext*)v_ctx;
   float ax, ay;
   NVGpaint img_pattern;
-  
+
   // get the mapped image_id for this driver_id
   image_t* p_image = get_image(id);
   if (!p_image) return;
@@ -377,6 +377,21 @@ void script_ops_quadratic_to(void* v_ctx,
 
   NVGcontext* p_ctx = (NVGcontext*)v_ctx;
   nvgQuadTo(p_ctx, c.x, c.y, a.x, a.y);
+}
+
+void script_ops_arc(void* v_ctx,
+                             coordinates_t c,
+                             float r,
+                             float a0, float a1,
+                             int sweep_dir)
+{
+  if (g_opts.debug_mode) {
+    log_script_ops_arc(log_prefix, __func__, log_level_info,
+                                c, r, a0, a1, sweep_dir);
+  }
+
+  NVGcontext* p_ctx = (NVGcontext*)v_ctx;
+  nvgArc(p_ctx, c.x, c.y, r, a0, a1, sweep_dir);
 }
 
 void script_ops_push_state(void* v_ctx)

--- a/c_src/scenic/ops/nvg_script_ops.c
+++ b/c_src/scenic/ops/nvg_script_ops.c
@@ -379,11 +379,11 @@ void script_ops_quadratic_to(void* v_ctx,
   nvgQuadTo(p_ctx, c.x, c.y, a.x, a.y);
 }
 
-void script_ops_arc(void* v_ctx,
-                             coordinates_t c,
-                             float r,
-                             float a0, float a1,
-                             int sweep_dir)
+void script_ops_arc(void *v_ctx,
+                    coordinates_t c,
+                    float r,
+                    float a0, float a1,
+                    sweep_dir_t sweep_dir)
 {
   if (g_opts.debug_mode) {
     log_script_ops_arc(log_prefix, __func__, log_level_info,

--- a/c_src/scenic/ops/script_ops.c
+++ b/c_src/scenic/ops/script_ops.c
@@ -341,6 +341,26 @@ void log_script_ops_quadratic_to(const char* prefix, const char* func, log_level
 }
 
 __attribute__((weak))
+void script_ops_arc(void* v_ctx, coordinates_t c, float r, float a0, float a1, int sweep_dir)
+{
+  log_script_ops_arc(log_prefix, __func__, log_level_warn, c, r, a0, a1, sweep_dir);
+}
+void log_script_ops_arc(const char *prefix, const char *func, log_level_t level, coordinates_t c, float r, float a0, float a1, int sweep_dir)
+{
+  log_message(level, "%s %s: %{"
+                     "c: {x:%.1f, y:%.1f}, "
+                     "r: %.1f, "
+                     "a0:%.1f, a1:%.1f"
+                     "s: %s"
+                     "}",
+              prefix, func,
+              c.x, c.y,
+              r,
+              a0, a1,
+              (sweep_dir == FLAG_CCW) ? "CCW" : "CW");
+}
+
+__attribute__((weak))
 void script_ops_push_state(void* v_ctx)
 {
   log_script_ops_push_state(log_prefix, __func__, log_level_warn);
@@ -772,6 +792,7 @@ const char* script_op_to_string(script_op_t op)
   case SCRIPT_OP_ARC_TO: return "script_op_arc_to";
   case SCRIPT_OP_BEZIER_TO: return "script_op_bezier_to";
   case SCRIPT_OP_QUADRATIC_TO: return "script_op_quadratic_to";
+  case SCRIPT_OP_ARC: return "script_op_arc";
 
   case SCRIPT_OP_PUSH_STATE: return "script_op_push_state";
   case SCRIPT_OP_POP_STATE: return "script_op_pop_state";

--- a/c_src/scenic/ops/script_ops.c
+++ b/c_src/scenic/ops/script_ops.c
@@ -341,11 +341,11 @@ void log_script_ops_quadratic_to(const char* prefix, const char* func, log_level
 }
 
 __attribute__((weak))
-void script_ops_arc(void* v_ctx, coordinates_t c, float r, float a0, float a1, int sweep_dir)
+void script_ops_arc(void *v_ctx, coordinates_t c, float r, float a0, float a1, sweep_dir_t sweep_dir)
 {
   log_script_ops_arc(log_prefix, __func__, log_level_warn, c, r, a0, a1, sweep_dir);
 }
-void log_script_ops_arc(const char *prefix, const char *func, log_level_t level, coordinates_t c, float r, float a0, float a1, int sweep_dir)
+void log_script_ops_arc(const char *prefix, const char *func, log_level_t level, coordinates_t c, float r, float a0, float a1, sweep_dir_t sweep_dir)
 {
   log_message(level, "%s %s: %{"
                      "c: {x:%.1f, y:%.1f}, "
@@ -357,7 +357,7 @@ void log_script_ops_arc(const char *prefix, const char *func, log_level_t level,
               c.x, c.y,
               r,
               a0, a1,
-              (sweep_dir == FLAG_CCW) ? "CCW" : "CW");
+              (sweep_dir == SWEEP_DIR_CCW) ? "SWEEP_CCW" : "SWEEP_CW");
 }
 
 __attribute__((weak))

--- a/c_src/scenic/ops/script_ops.h
+++ b/c_src/scenic/ops/script_ops.h
@@ -25,6 +25,7 @@ typedef enum {
   SCRIPT_OP_ARC_TO = 0X28,
   SCRIPT_OP_BEZIER_TO = 0X29,
   SCRIPT_OP_QUADRATIC_TO = 0X2A,
+  SCRIPT_OP_ARC = 0X32,
 
   SCRIPT_OP_PUSH_STATE = 0X40,
   SCRIPT_OP_POP_STATE = 0X41,
@@ -122,6 +123,11 @@ typedef enum {
   FLAG_STROKE = 0X02,
 } fill_stroke_t;
 
+typedef enum {
+  FLAG_CCW = 0X01,
+  FLAG_CW = 0X02,
+} sweep_dir_t;
+
 #define SCRIPT_FUNC(name, args...) \
   void script_ops_ ## name(void* v_ctx, ##args); \
   void log_script_ops_ ## name(const char* prefix, const char* func, log_level_t level, ##args);
@@ -148,6 +154,7 @@ SCRIPT_FUNC(line_to, coordinates_t a);
 SCRIPT_FUNC(arc_to, coordinates_t a, coordinates_t b, float radius);
 SCRIPT_FUNC(bezier_to, coordinates_t c0, coordinates_t c1, coordinates_t a);
 SCRIPT_FUNC(quadratic_to, coordinates_t c, coordinates_t a);
+SCRIPT_FUNC(arc, coordinates_t c, float radius, float a0, float a1, int sweep_dir);
 
 SCRIPT_FUNC(push_state);
 SCRIPT_FUNC(pop_state);

--- a/c_src/scenic/ops/script_ops.h
+++ b/c_src/scenic/ops/script_ops.h
@@ -124,8 +124,8 @@ typedef enum {
 } fill_stroke_t;
 
 typedef enum {
-  FLAG_CCW = 0X01,
-  FLAG_CW = 0X02,
+  SWEEP_DIR_CCW = 0X01,
+  SWEEP_DIR_CW = 0X02,
 } sweep_dir_t;
 
 #define SCRIPT_FUNC(name, args...) \
@@ -154,7 +154,7 @@ SCRIPT_FUNC(line_to, coordinates_t a);
 SCRIPT_FUNC(arc_to, coordinates_t a, coordinates_t b, float radius);
 SCRIPT_FUNC(bezier_to, coordinates_t c0, coordinates_t c1, coordinates_t a);
 SCRIPT_FUNC(quadratic_to, coordinates_t c, coordinates_t a);
-SCRIPT_FUNC(arc, coordinates_t c, float radius, float a0, float a1, int sweep_dir);
+SCRIPT_FUNC(arc, coordinates_t c, float radius, float a0, float a1, sweep_dir_t sweep_dir);
 
 SCRIPT_FUNC(push_state);
 SCRIPT_FUNC(pop_state);

--- a/c_src/scenic/script.c
+++ b/c_src/scenic/script.c
@@ -369,6 +369,17 @@ void render_script(void* v_ctx, sid_t id)
         }
         i += 16;
         break;
+      case SCRIPT_OP_ARC:
+        {
+          coordinates_t c = {get_float(p, i), get_float(p, i + 4)};
+          float radius = get_float(p, i + 8);
+          float a0 = get_float(p, i + 12);
+          float a1 = get_float(p, i + 16);
+          sweep_dir_t sweep_dir = get_uint32(p, i + 20);
+          script_ops_arc(v_ctx, c, radius, a0, a1, sweep_dir);
+        }
+        i += 24;
+        break;
       case SCRIPT_OP_POP_STATE:
         if (push_count > 0) {
           push_count--;


### PR DESCRIPTION
This PR adds a new operation `arc` to add arcs to current path.

### Motivation

Today we only have 2 interfaces to have arcs:
 1. `draw_arc/4`: which draws an arc on a _new path_;
 2. `arc_to/6`: which adds an arc on the current path.

The need for a third arc operation is that none of the above functions provide a flexible interface for arcs as the `nvgArc` does.

So this new operation `arc` have the same parameters as `nvgArc`, which gives a more flexible interface for drawing arcs.

### Further notes

This PR is a dependency to https://github.com/ScenicFramework/scenic/pull/326, thus it should be merged first.