### PR TITLE
Fix various issues with bcm.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,12 @@ else ifeq ($(SCENIC_LOCAL_TARGET),bcm)
 	IMAGE_SRCS += c_src/image/nvg_image_ops.c
 	SCENIC_SRCS += c_src/scenic/ops/nvg_script_ops.c
 
+	ifeq ($(SCENIC_LOCAL_GL),gles2)
+		CFLAGS += -DSCENIC_GLES2
+	else
+		CFLAGS += -DSCENIC_GLES3
+	endif
+
 else ifeq ($(SCENIC_LOCAL_TARGET),drm)
 	# drm is the forward looking default
 	LDFLAGS += -lGLESv2 -lEGL -lm -lvchostif -ldrm -lgbm
@@ -122,7 +128,7 @@ else ifeq ($(SCENIC_LOCAL_TARGET),drm)
 
 	ifeq ($(SCENIC_LOCAL_GL),gles2)
 		CFLAGS += -DSCENIC_GLES2
-	else 
+	else
 		CFLAGS += -DSCENIC_GLES3
 	endif
 else

--- a/c_src/device/bcm.c
+++ b/c_src/device/bcm.c
@@ -253,14 +253,14 @@ void device_poll()
 
 void device_begin_render(driver_data_t* p_data)
 {
-  NVGcontext* v_ctx = p_data->v_ctx;
+  NVGcontext* p_ctx = p_data->v_ctx;
 
   glClear(GL_COLOR_BUFFER_BIT);
 
-  nvgBeginFrame(v_ctx, g_device_info.width, g_device_info.height, g_device_info.ratio);
+  nvgBeginFrame(p_ctx, g_device_info.width, g_device_info.height, g_device_info.ratio);
 
   // set the global transform
-  nvgTransform(v_ctx,
+  nvgTransform(p_ctx,
                p_data->global_tx[0], p_data->global_tx[1],
                p_data->global_tx[2], p_data->global_tx[3],
                p_data->global_tx[4], p_data->global_tx[5]);
@@ -268,18 +268,18 @@ void device_begin_render(driver_data_t* p_data)
 
 void device_begin_cursor_render(driver_data_t* p_data)
 {
-  NVGcontext* v_ctx = p_data->v_ctx;
-	nvgTranslate(v_ctx,
+  NVGcontext* p_ctx = p_data->v_ctx;
+	nvgTranslate(p_ctx,
 	             p_data->cursor_pos[0], p_data->cursor_pos[1]);
 }
 
 void device_end_render(driver_data_t* p_data)
 {
-  NVGcontext* v_ctx = p_data->v_ctx;
+  NVGcontext* p_ctx = p_data->v_ctx;
 
   // End frame and swap front and back buffers
   //uint64_t time = monotonic_time();
-  nvgEndFrame(v_ctx);
+  nvgEndFrame(p_ctx);
   //log_info("nvgEndFrame: %" PRId64, monotonic_time() - time);
 
   //time = monotonic_time();

--- a/c_src/device/bcm.c
+++ b/c_src/device/bcm.c
@@ -253,7 +253,7 @@ void device_poll()
 
 void device_begin_render(driver_data_t* p_data)
 {
-  NVGcontext* p_ctx = p_data->v_ctx;
+  NVGcontext* p_ctx = (NVGcontext*)p_data->v_ctx;
 
   glClear(GL_COLOR_BUFFER_BIT);
 
@@ -268,14 +268,14 @@ void device_begin_render(driver_data_t* p_data)
 
 void device_begin_cursor_render(driver_data_t* p_data)
 {
-  NVGcontext* p_ctx = p_data->v_ctx;
+  NVGcontext* p_ctx = (NVGcontext*)p_data->v_ctx;
 	nvgTranslate(p_ctx,
 	             p_data->cursor_pos[0], p_data->cursor_pos[1]);
 }
 
 void device_end_render(driver_data_t* p_data)
 {
-  NVGcontext* p_ctx = p_data->v_ctx;
+  NVGcontext* p_ctx = (NVGcontext*)p_data->v_ctx;
 
   // End frame and swap front and back buffers
   //uint64_t time = monotonic_time();

--- a/c_src/device/bcm.c
+++ b/c_src/device/bcm.c
@@ -41,11 +41,13 @@ typedef struct {
 
 egl_data_t g_egl_data = {0};
 
+extern device_info_t g_device_info;
+
 //---------------------------------------------------------
 // setup the video core
 int device_init(const device_opts_t* p_opts,
                 device_info_t* p_info,
-                device_data_t* p_data)
+                driver_data_t* p_data)
 {
   // initialize the global transform to the identity matrix
   nvgTransformIdentity(p_data->global_tx);
@@ -227,8 +229,8 @@ int device_init(const device_opts_t* p_opts,
   uint32_t nvg_opts = 0;
   if (p_opts->antialias) nvg_opts |= NVG_ANTIALIAS;
   if (p_opts->debug_mode) nvg_opts |= NVG_DEBUG;
-  p_info->p_ctx = nvgCreateGLES2(nvg_opts);
-  if (p_info->p_ctx == NULL) {
+  p_info->v_ctx = nvgCreateGLES2(nvg_opts);
+  if (p_info->v_ctx == NULL) {
     log_error("RPI driver error: failed nvgCreateGLES2");
     return 0;
   }
@@ -251,14 +253,14 @@ void device_poll()
 
 void device_begin_render(driver_data_t* p_data)
 {
-  NVGcontext* p_ctx = p_data->p_ctx;
+  NVGcontext* v_ctx = p_data->v_ctx;
 
   glClear(GL_COLOR_BUFFER_BIT);
 
-  nvgBeginFrame(p_ctx, g_device_info.width, g_device_info.height, g_device_info.ratio);
+  nvgBeginFrame(v_ctx, g_device_info.width, g_device_info.height, g_device_info.ratio);
 
   // set the global transform
-  nvgTransform(p_ctx,
+  nvgTransform(v_ctx,
                p_data->global_tx[0], p_data->global_tx[1],
                p_data->global_tx[2], p_data->global_tx[3],
                p_data->global_tx[4], p_data->global_tx[5]);
@@ -266,18 +268,18 @@ void device_begin_render(driver_data_t* p_data)
 
 void device_begin_cursor_render(driver_data_t* p_data)
 {
-  NVGcontext* p_ctx = p_data->p_ctx;
-	nvgTranslate(p_ctx,
+  NVGcontext* v_ctx = p_data->v_ctx;
+	nvgTranslate(v_ctx,
 	             p_data->cursor_pos[0], p_data->cursor_pos[1]);
 }
 
 void device_end_render(driver_data_t* p_data)
 {
-  NVGcontext* p_ctx = p_data->p_ctx;
+  NVGcontext* v_ctx = p_data->v_ctx;
 
   // End frame and swap front and back buffers
   //uint64_t time = monotonic_time();
-  nvgEndFrame(p_ctx);
+  nvgEndFrame(v_ctx);
   //log_info("nvgEndFrame: %" PRId64, monotonic_time() - time);
 
   //time = monotonic_time();

--- a/c_src/device/drm.c
+++ b/c_src/device/drm.c
@@ -561,7 +561,7 @@ int init_egl(const device_opts_t* p_opts, device_info_t* p_info)
 
 int device_init(const device_opts_t* p_opts,
                 device_info_t* p_info,
-                device_data_t* p_data)
+                driver_data_t* p_data)
 {
   int ret;
 

--- a/c_src/device/gl_helpers.c
+++ b/c_src/device/gl_helpers.c
@@ -1,7 +1,7 @@
 #include <stddef.h>
 
 #ifdef SCENIC_GLES2
-  #include <GLES3/gl2.h>
+  #include <GLES2/gl2.h>
 #else
   #ifdef __APPLE__
     #include <OpenGL/gl3.h>


### PR DESCRIPTION
bcm mode seems to have broken with https://github.com/ScenicFramework/scenic_driver_local/pull/27

This PR fixes these breakages:
- `g_device_info` was referred to in `bcm.c` without being defined/externed
- `device_data_t` doesn't exist, it should be `driver_data_t` instead
- There are many references to a non-existant `driver_data_t.p_ctx` which was renamed to `v_ctx`
- An apparently non-existant GLES3/gl2.h was loaded
  - This include already existed but we weren't hitting it before

With these changes bcm mode can at least render basic text although I haven't tried a more full-featured program.

Fixes https://github.com/ScenicFramework/scenic_driver_local/issues/41 along with other issues