### PR TITLE
Fix malloc of sprite_t array

### DIFF
--- a/c_src/scenic/script.c
+++ b/c_src/scenic/script.c
@@ -281,7 +281,7 @@ void render_script(void* v_ctx, sid_t id)
       case SCRIPT_OP_DRAW_SPRITES:
         {
           uint32_t count = get_uint32(p, i);
-          sprite_t* sprites = malloc(count * sizeof(sprites));
+          sprite_t* sprites = malloc(count * sizeof(sprite_t));
 
           i += sizeof(uint32_t);
 


### PR DESCRIPTION
This addresses https://github.com/ScenicFramework/scenic_driver_local/issues/45