### PR TITLE
Default cairo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         key: ${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
 
     - name: Install build-deps
-      run: sudo apt update && sudo apt-get install -y build-essential libglfw3 libglfw3-dev libglew2.2 libglew-dev
+      run: sudo apt update && sudo apt-get install -y build-essential libgtk-3-0 libgtk-3-dev libsystemd-dev libwebp-dev libzstd-dev
 
     - name: Install Dependencies
       run: |

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ NVG_COMMON_SRCS = \
 	c_src/device/nvg/nanovg/nanovg.c \
 	c_src/device/nvg/nvg_font_ops.c \
 	c_src/device/nvg/nvg_image_ops.c \
+	c_src/device/nvg/nvg_scenic.c \
 	c_src/device/nvg/nvg_script_ops.c
 
 CAIRO_COMMON_SRCS = \

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,6 @@
-# Variables to override
-#
-# CC            C compiler
-# CROSSCOMPILE	crosscompiler prefix, if any
-# CFLAGS	compiler flags for compiling all C files
-# ERL_CFLAGS	additional compiler flags for files using Erlang header files
-# ERL_EI_INCLUDE_DIR include path to ei.h (Required for crosscompile)
-# ERL_EI_LIBDIR path to libei.a (Required for crosscompile)
-# LDFLAGS	linker flags for linking all binaries
-# ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
-
-
 MIX = mix
 PREFIX = $(MIX_APP_PATH)/priv
 DEFAULT_TARGETS ?= $(PREFIX) $(PREFIX)/scenic_driver_local
-
-# # Look for the EI library and header files
-# # For crosscompiled builds, ERL_EI_INCLUDE_DIR and ERL_EI_LIBDIR must be
-# # passed into the Makefile.
-# ifeq ($(ERL_EI_INCLUDE_DIR),)
-# ERL_ROOT_DIR = $(shell erl -eval "io:format(\"~s~n\", [code:root_dir()])" -s init stop -noshell)
-# ifeq ($(ERL_ROOT_DIR),)
-# 	$(error Could not find the Erlang installation. Check to see that 'erl' is in your PATH)
-# endif
-# ERL_EI_INCLUDE_DIR = "$(ERL_ROOT_DIR)/usr/include"
-# ERL_EI_LIBDIR = "$(ERL_ROOT_DIR)/usr/lib"
-# endif
-
-# # Set Erlang-specific compile and linker flags
-# ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR)
-# ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR) -lei
-
 
 $(info SCENIC_LOCAL_TARGET: $(SCENIC_LOCAL_TARGET))
 ifdef SCENIC_LOCAL_GL
@@ -70,7 +41,47 @@ CAIRO_COMMON_SRCS = \
 	c_src/device/cairo/cairo_image_ops.c \
 	c_src/device/cairo/cairo_script_ops.c
 
-ifeq ($(SCENIC_LOCAL_TARGET),glfw)
+ifeq ($(SCENIC_LOCAL_TARGET),cairo-gtk)
+	CFLAGS = -O3 -std=gnu99
+
+	ifndef MIX_ENV
+		MIX_ENV = dev
+	endif
+
+	ifdef DEBUG
+		CFLAGS += -O0 -pedantic -Wall -Wextra -Wno-unused-parameter
+	endif
+
+	ifeq ($(MIX_ENV),dev)
+		CFLAGS += -g
+	endif
+
+	LDFLAGS += `pkg-config --static --libs freetype2 cairo gtk+-3.0`
+	CFLAGS += `pkg-config --static --cflags freetype2 cairo gtk+-3.0`
+	LDFLAGS += -lm
+
+	DEVICE_SRCS += \
+		$(CAIRO_COMMON_SRCS) \
+		c_src/device/cairo/cairo_gtk.c
+
+else ifeq ($(SCENIC_LOCAL_TARGET),cairo-fb)
+	LDFLAGS += `pkg-config --static --libs freetype2 cairo`
+	CFLAGS += `pkg-config --static --cflags freetype2 cairo`
+	LDFLAGS += -lm
+	CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
+	CFLAGS += -std=gnu99
+
+	DEVICE_SRCS += \
+		$(CAIRO_COMMON_SRCS) \
+		c_src/device/cairo/cairo_fb.c
+
+else ifeq ($(SCENIC_LOCAL_TARGET),glfw)
+$(info )
+$(info **********************************************************************************)
+$(info SCENIC_LOCAL_TARGET=glfw is deprecated. Please use `SCENIC_LOCAL_TARGET=cairo-gtk`)
+$(info **********************************************************************************)
+$(info )
+
 	CFLAGS = -O3 -std=c99
 
 	ifndef MIX_ENV
@@ -103,6 +114,12 @@ ifeq ($(SCENIC_LOCAL_TARGET),glfw)
 		c_src/device/nvg/glfw.c
 
 else ifeq ($(SCENIC_LOCAL_TARGET),bcm)
+$(info )
+$(info ********************************************************************************)
+$(info SCENIC_LOCAL_TARGET=bcm is deprecated. Please use `SCENIC_LOCAL_TARGET=cairo-fb`)
+$(info ********************************************************************************)
+$(info )
+
 	LDFLAGS += -lGLESv2 -lEGL -lm -lvchostif -lbcm_host
 	CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 	CFLAGS += -std=gnu99
@@ -118,7 +135,12 @@ else ifeq ($(SCENIC_LOCAL_TARGET),bcm)
 	endif
 
 else ifeq ($(SCENIC_LOCAL_TARGET),drm)
-	# drm is the forward looking default
+$(info )
+$(info ********************************************************************************)
+$(info SCENIC_LOCAL_TARGET=drm is deprecated. Please use `SCENIC_LOCAL_TARGET=cairo-fb`)
+$(info ********************************************************************************)
+$(info )
+
 	LDFLAGS += -lGLESv2 -lEGL -lm -lvchostif -ldrm -lgbm
 	CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 	CFLAGS += -std=gnu99
@@ -134,53 +156,8 @@ else ifeq ($(SCENIC_LOCAL_TARGET),drm)
 		CFLAGS += -DSCENIC_GLES3
 	endif
 
-else ifeq ($(SCENIC_LOCAL_TARGET),cairo-fb)
-	LDFLAGS += `pkg-config --static --libs freetype2 cairo`
-	CFLAGS += `pkg-config --static --cflags freetype2 cairo`
-	LDFLAGS += -lm
-	CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
-	CFLAGS += -std=gnu99
-
-	DEVICE_SRCS += \
-		$(CAIRO_COMMON_SRCS) \
-		c_src/device/cairo/cairo_fb.c
-
-else ifeq ($(SCENIC_LOCAL_TARGET),cairo-gtk)
-	LDFLAGS += `pkg-config --static --libs freetype2 cairo gtk+-3.0`
-	CFLAGS += `pkg-config --static --cflags freetype2 cairo gtk+-3.0`
-	LDFLAGS += -lm
-	CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
-	CFLAGS += -std=gnu99
-
-	DEVICE_SRCS += \
-		$(CAIRO_COMMON_SRCS) \
-		c_src/device/cairo/cairo_gtk.c
-else
-$(info ------ no SCENIC_LOCAL_TARGET set ------)
-$(info If you get here, then you are probably using a custom Nerves system)
-$(info Please export/set SCENIC_LOCAL_TARGET to one of [glfw, bcm, drm])
-$(info If you are running on a desktop machine, pick: glfw)
-$(info For any varient of rpi <= 3, pick: bcm)
-$(info For any varient of rpi >= 4, pick: drm)
-$(info For any varient of bbb, pick: drm)
-$(info example for a custom rpi3 build system:)
-$(info export SCENIC_LOCAL_TARGET=bcm)
-$(info For bbb, you also need to set SCENIC_LOCAL_GL=gles2)
-$(info For >= rpi4, you also need to set SCENIC_LOCAL_GL=gles3)
-$(info ----------------------------------------)
 endif
 
-# ifeq ($(SCENIC_LOCAL_TARGET),drm_gles3)
-# 	LDFLAGS += -lGLESv2 -lEGL -lm -lvchostif -ldrm -lgbm
-# 	CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
-# 	CFLAGS += -std=gnu99
-
-# 	CFLAGS += -fPIC -I$(NERVES_SDK_SYSROOT)/usr/include/drm
-
-# 	SRCS = c_src/device/drm_gles3.c
-# endif
-
-# $(info $(shell printenv))
 CFLAGS += \
 	-Ic_src \
 	-Ic_src/device \

--- a/README.md
+++ b/README.md
@@ -37,36 +37,17 @@ There are quite a few new options as well. It uses `NimbleOptions` to confirm th
 
 ## Targets
 
-This driver does its best to figure out what underlying graphics technology to use depending on what your MIX_TARGET is set to.
+This driver figures out what underlying graphics technology to use depending on what your MIX_TARGET is set to.
 
-For example, for apps running on a Mac/PC/Linux, it is usually set to `host`, which causes the driver to use `glfw` as the underlying tech.
+For example, for apps running on a Mac/PC/Linux, it is usually set to `host`, which causes the driver to use `cairo-gtk` as the underlying tech.
 
-If you are building for Nerves, it will use `bcm` (Broadcom Manager) for any of `rpi`, `rpi0`, `rip2`, `rpi3`, and `rpi3a`.
+If you are building for Nerves, it will use `cairo-fb`
 
-### Cairo
-There is now a rendering backend to use `cairo`. You can set SCENIC_LOCAL_TARGET to `cairo-fb` which renders to `/dev/fb0` on an embedded device or `cairo-gtk` which renders to a window on a host (as an alternative to `glfw`).
+Previous versions of `scenic_driver_local` would use `bcm` (Broadcom Manager) for any of `rpi`, `rpi0`, `rip2`, `rpi3`, and `rpi3a` and `drm` for `bbb` and `rpi4`.
+You can explicitly use thes by setting `SCENIC_LOCAL_TARGET=bcm` or `SCENIC_LOCAL_TARGET=drm`, **but these options are being deprecated**.
+Please try the default of `SCENIC_LOCAL_TARGET=cairo-fb` as this should work universally on any Nerves target.
 
 `cairo-fb` will require that your `nerves_system_*` has the `cairo` library selected.
-
-### Nerves rpi4 & bbb Need Work / Help
-`Scenic.Driver.Local` uses `drm` (Direct Render Manager) for the `rpi4` and `bbb`. It currently renders on the rpi4, but is __very slow__. I haven't figured out why yet and if anyone wants to dig in, that would be appreciated. It should be really fast, so is probably a hardware configuration issue.
-
-The `bbb` doesn't work (is close in theory??) as the Nerves `bbb` system doesn't have the needed graphics support in it yet. There are others who have gotten SGX support working for the `bbb` and I could use some help from them.
-
-Please try using `cairo-fb` to see if it will work for you on `rpi4` or `bbb`.
-
-### Custom Nerves Targets
-For custom systems (example - figuring out how to add SGX support to the `bbb`) You will need to set SCENIC_LOCAL_TARGET manually. You may also need to set the SCENIC_LOCAL_GL as well.
-
-example in your command line
-
-```
-export SCENIC_LOCAL_TARGET=drm
-export SCENIC_LOCAL_GL=gles3
-```
-
-These options may change, especially as we sort out the issues on the `rpi4` and the `bbb`. If SCENIC_LOCAL_TARGET isn't set, then look in the build output for instructions.
-
 
 ## Prerequisites
 
@@ -74,38 +55,21 @@ This driver requires Scenic v0.11 or up.
 
 ### Installing on MacOS
 
-The easiest way to install on MacOS is to use Homebrew. Just run the following in a terminal:
+You will need to install [XQuartz](https://www.xquartz.org/) on macOS.
+
+The easiest way to install needed build time dependencies on MacOS is to use Homebrew. Just run the following in a terminal:
 
 ```bash
 brew update
-brew install glfw3 glew pkg-config
-```
-
-
-Once these components have been installed, you should be able to build the `scenic_driver_local` driver.
-
-### Installing on Ubuntu 18.04
-
-The easiest way to install on Ubuntu is to use apt-get. Just run the following:
-
-```bash
-apt-get update
-apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
+brew install gtk+3 cairo pkg-config
 ```
 
 Once these components have been installed, you should be able to build the `scenic_driver_local` driver.
 
-### Installing on Ubuntu 20.04
+### Installing on Ubuntu
 
 The easiest way to install on Ubuntu is to use apt-get. Just run the following:
 
-For `glfw`:
-```bash
-apt-get update
-apt-get install pkgconf libglfw3 libglfw3-dev libglew2.1 libglew-dev
-```
-
-For `cairo-gtk`:
 ```bash
 apt-get update
 apt-get install pkgconf libgtk-3-0 libgtk-3-dev libsystemd-dev libwebp-dev libzstd-dev
@@ -120,12 +84,12 @@ The easiest way to install on Arch Linux is to use pacman. Just run the followin
 
 ```bash
 pacman -Syu
-sudo pacman -S glfw-x11 glew
+sudo pacman -S cairo gtk3
 ```
 
-If you're using Wayland, you'll probably need `glfw-wayland` instead of `glfw-x11` and `glew-wayland` instead of `glew`
-
 ### Installing on Windows
+
+**This section needs help updating for cairo support**
 
 First, make sure to have installed Visual Studio with its "Desktop development with C++" package.
 

--- a/c_src/device/cairo/cairo_fb.c
+++ b/c_src/device/cairo/cairo_fb.c
@@ -12,6 +12,7 @@
 #include "comms.h"
 #include "device.h"
 #include "fontstash.h"
+#include "scenic_ops.h"
 
 const char* device = "/dev/fb0";
 
@@ -326,5 +327,10 @@ void device_end_render(driver_data_t* p_data)
 
   scenic_cairo_ctx_t* p_ctx = (scenic_cairo_ctx_t*)p_data->v_ctx;
   render_cairo_surface_to_fb(p_ctx);
+}
+
+void device_loop(driver_data_t* p_data)
+{
+  scenic_loop(p_data);
 }
 

--- a/c_src/device/cairo/cairo_gtk.c
+++ b/c_src/device/cairo/cairo_gtk.c
@@ -1,7 +1,6 @@
 #include <cairo.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <linux/fb.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>

--- a/c_src/device/cairo/cairo_script_ops.c
+++ b/c_src/device/cairo/cairo_script_ops.c
@@ -1,4 +1,5 @@
 #include <cairo.h>
+#define _GNU_SOURCE
 #include <math.h>
 
 #include "cairo_ctx.h"
@@ -258,7 +259,7 @@ void script_ops_draw_text(void* v_ctx,
   cairo_text_extents_t text_extents;
   cairo_scaled_font_glyph_extents(scaled_font, glyphs, glyph_count, &text_extents);
 
-  float align_offset;
+  float align_offset = 0;
   switch (p_ctx->text_align) {
   case TEXT_ALIGN_LEFT:
     align_offset = 0;
@@ -271,7 +272,7 @@ void script_ops_draw_text(void* v_ctx,
     break;
   }
 
-  float base_offset;
+  float base_offset = 0;
   switch (p_ctx->text_base) {
   case TEXT_BASE_TOP:
     base_offset = font_extents.ascent;
@@ -345,7 +346,7 @@ void script_ops_draw_sprites(void* v_ctx,
 
   image_pattern_data_t* image_data = find_image_pattern(p_ctx, p_image->image_id);
 
-  for (int i = 0; i < count; i++) {
+  for (uint32_t i = 0; i < count; i++) {
     draw_sprite(p_ctx, image_data->surface, sprites[i]);
   }
 }

--- a/c_src/device/device.h
+++ b/c_src/device/device.h
@@ -13,6 +13,7 @@ int device_init(const device_opts_t* p_opts,
                 driver_data_t* p_data);
 int device_close(device_info_t* p_info);
 void device_poll();
+void device_loop(driver_data_t* p_data);
 void device_begin_render(driver_data_t* p_data);
 void device_begin_cursor_render(driver_data_t* p_data);
 void device_end_render(driver_data_t* p_data);

--- a/c_src/device/nvg/nvg_scenic.c
+++ b/c_src/device/nvg/nvg_scenic.c
@@ -1,0 +1,7 @@
+#include "device.h"
+#include "scenic_ops.h"
+
+void device_loop(driver_data_t* p_data)
+{
+  scenic_loop(p_data);
+}

--- a/c_src/font/font.c
+++ b/c_src/font/font.c
@@ -52,7 +52,7 @@ font_t* get_font(sid_t id)
 }
 
 //---------------------------------------------------------
-void put_font(int* p_msg_length, void* v_ctx)
+void put_font(uint32_t* p_msg_length, void* v_ctx)
 {
   // read in the id size, which is in the first four bytes
   uint32_t id_length;

--- a/c_src/font/font.h
+++ b/c_src/font/font.h
@@ -10,6 +10,6 @@
 #include "font_ops.h"
 
 void init_fonts(void);
-void put_font(int* p_msg_length, void* v_ctx);
+void put_font(uint32_t* p_msg_length, void* v_ctx);
 font_t* get_font(sid_t id);
 

--- a/c_src/image/image.c
+++ b/c_src/image/image.c
@@ -145,6 +145,8 @@ int read_pixels(void* p_pixels,
   case IMAGE_FORMAT_RGBA:
     memcpy(p_pixels, p_buffer, pixel_count * 4);
     break;
+  default:
+    break;
   }
 
   // clean up

--- a/c_src/image/image.c
+++ b/c_src/image/image.c
@@ -80,7 +80,7 @@ void reset_images(void* v_ctx)
 int read_pixels(void* p_pixels,
                 uint32_t width, uint32_t height,
                 image_format_t format_in,
-                int* p_msg_length)
+                uint32_t* p_msg_length)
 {
   // read incoming data into a temporary buffer
   int buffer_size = *p_msg_length;
@@ -154,7 +154,7 @@ int read_pixels(void* p_pixels,
 }
 
 //---------------------------------------------------------
-void put_image(int* p_msg_length, void* v_ctx)
+void put_image(uint32_t* p_msg_length, void* v_ctx)
 {
   // read in the fixed size data
   uint32_t id_length;

--- a/c_src/image/image.c
+++ b/c_src/image/image.c
@@ -10,9 +10,9 @@
 #include "common.h"
 #include "comms.h"
 #include "image.h"
+#include "image_ops.h"
 #include "scenic_types.h"
 #include "utils.h"
-#include "image_ops.h"
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"

--- a/c_src/image/image.h
+++ b/c_src/image/image.h
@@ -25,7 +25,6 @@ typedef enum {
   IMAGE_FORMAT_GRAY_ALPHA = 2,
   IMAGE_FORMAT_RGB = 3,
   IMAGE_FORMAT_RGBA = 4,
-  IMAGE_FORMAT_SIZE = 0xffffffff, // ensure enum is 32 bits wide
 } image_format_t;
 
 void init_images(void);

--- a/c_src/image/image.h
+++ b/c_src/image/image.h
@@ -29,6 +29,6 @@ typedef enum {
 } image_format_t;
 
 void init_images(void);
-void put_image(int* p_msg_length, void* v_ctx);
+void put_image(uint32_t* p_msg_length, void* v_ctx);
 void reset_images(void* v_ctx);
 image_t* get_image(sid_t id);

--- a/c_src/main.c
+++ b/c_src/main.c
@@ -63,23 +63,8 @@ int main(int argc, char **argv)
   data.debug_mode = g_opts.debug_mode;
   data.v_ctx = g_device_info.v_ctx;
 
-  // signal the app that the window is ready
-  send_ready();
+  device_loop(&data);
 
-#ifdef SCENIC_GLES2
-  log_info("~~~~~~~~~~~~~SCENIC_GLES2 was defined!");
-#endif
-
-  /* Loop until the calling app closes the window */
-  while (data.keep_going && !isCallerDown()) {
-    // check for incoming messages - blocks with a timeout
-    handle_stdio_in(&data);
-    device_poll();
-  }
-
-  reset_images(data.v_ctx);
-
-  device_close(&g_device_info);
   return 0;
 }
 

--- a/c_src/scenic/comms.c
+++ b/c_src/scenic/comms.c
@@ -45,13 +45,13 @@ extern device_info_t g_device_info;
 
 //---------------------------------------------------------
 // the length indicator from erlang is always big-endian
-int write_cmd(byte* buf, unsigned int len)
+int write_cmd(uint8_t* buf, unsigned int len)
 {
   int written = 0;
 
   uint32_t cmd_len = len;
   cmd_len = hton_ui32(cmd_len);
-  write_exact((byte*) &cmd_len, sizeof(uint32_t));
+  write_exact((uint8_t*) &cmd_len, sizeof(uint32_t));
   written = write_exact(buf, len);
 
   return written;
@@ -89,9 +89,9 @@ void logv(uint32_t cmd, const char* msg, va_list args)
   uint32_t msg_len = vasprintf(&output, msg, args);
   uint32_t cmd_len = ntoh_ui32(msg_len + sizeof(uint32_t));
 
-  write_exact((byte*) &cmd_len, sizeof(uint32_t));
-  write_exact((byte*) &cmd, sizeof(uint32_t));
-  write_exact((byte*) output, msg_len);
+  write_exact((uint8_t*) &cmd_len, sizeof(uint32_t));
+  write_exact((uint8_t*) &cmd, sizeof(uint32_t));
+  write_exact((uint8_t*) output, msg_len);
   free(output);
 }
 
@@ -163,9 +163,9 @@ void send_write(const char* msg)
 
   cmd_len = ntoh_ui32(cmd_len);
 
-  write_exact((byte*) &cmd_len, sizeof(uint32_t));
-  write_exact((byte*) &cmd, sizeof(uint32_t));
-  write_exact((byte*) msg, msg_len);
+  write_exact((uint8_t*) &cmd_len, sizeof(uint32_t));
+  write_exact((uint8_t*) &cmd, sizeof(uint32_t));
+  write_exact((uint8_t*) msg, msg_len);
 }
 
 //---------------------------------------------------------
@@ -176,8 +176,8 @@ void send_inspect(void* data, int length)
 
   ntoh_ui32(cmd_len);
 
-  write_exact((byte*) &cmd_len, sizeof(uint32_t));
-  write_exact((byte*) &cmd, sizeof(uint32_t));
+  write_exact((uint8_t*) &cmd_len, sizeof(uint32_t));
+  write_exact((uint8_t*) &cmd, sizeof(uint32_t));
   write_exact(data, length);
 }
 
@@ -190,9 +190,9 @@ void send_static_texture_miss(const char* key)
 
   ntoh_ui32(cmd_len);
 
-  write_exact((byte*) &cmd_len, sizeof(uint32_t));
-  write_exact((byte*) &cmd, sizeof(uint32_t));
-  write_exact((byte*) key, msg_len);
+  write_exact((uint8_t*) &cmd_len, sizeof(uint32_t));
+  write_exact((uint8_t*) &cmd, sizeof(uint32_t));
+  write_exact((uint8_t*) key, msg_len);
 }
 
 //---------------------------------------------------------
@@ -204,9 +204,9 @@ void send_dynamic_texture_miss(const char* key)
 
   ntoh_ui32(cmd_len);
 
-  write_exact((byte*) &cmd_len, sizeof(uint32_t));
-  write_exact((byte*) &cmd, sizeof(uint32_t));
-  write_exact((byte*) key, msg_len);
+  write_exact((uint8_t*) &cmd_len, sizeof(uint32_t));
+  write_exact((uint8_t*) &cmd, sizeof(uint32_t));
+  write_exact((uint8_t*) key, msg_len);
 }
 
 //---------------------------------------------------------
@@ -218,9 +218,9 @@ void send_font_miss(const char* key)
 
   ntoh_ui32(cmd_len);
 
-  write_exact((byte*) &cmd_len, sizeof(uint32_t));
-  write_exact((byte*) &cmd, sizeof(uint32_t));
-  write_exact((byte*) key, msg_len);
+  write_exact((uint8_t*) &cmd_len, sizeof(uint32_t));
+  write_exact((uint8_t*) &cmd, sizeof(uint32_t));
+  write_exact((uint8_t*) key, msg_len);
 }
 
 //---------------------------------------------------------
@@ -234,7 +234,7 @@ PACK(typedef struct msg_reshape_t
 void send_reshape( int window_width, int window_height )
 {
   msg_reshape_t msg = { MSG_OUT_RESHAPE, window_width, window_height };
-  write_cmd((byte*) &msg, sizeof(msg_reshape_t));
+  write_cmd((uint8_t*) &msg, sizeof(msg_reshape_t));
 }
 
 //---------------------------------------------------------
@@ -251,7 +251,7 @@ PACK(typedef struct msg_key_t
 void send_key(keymap_t keymap, int key, int scancode, int action, int mods)
 {
   msg_key_t msg = { MSG_OUT_KEY, keymap, key, scancode, action, mods };
-  write_cmd((byte*) &msg, sizeof(msg_key_t));
+  write_cmd((uint8_t*) &msg, sizeof(msg_key_t));
 }
 
 //---------------------------------------------------------
@@ -266,7 +266,7 @@ PACK(typedef struct msg_codepoint_t
 void send_codepoint(keymap_t keymap, unsigned int codepoint, int mods)
 {
   msg_codepoint_t msg = { MSG_OUT_CODEPOINT, keymap, codepoint, mods };
-  write_cmd((byte*) &msg, sizeof(msg_codepoint_t));
+  write_cmd((uint8_t*) &msg, sizeof(msg_codepoint_t));
 }
 
 //---------------------------------------------------------
@@ -280,7 +280,7 @@ PACK(typedef struct msg_cursor_pos_t
 void send_cursor_pos(float xpos, float ypos)
 {
   msg_cursor_pos_t msg = { MSG_OUT_CURSOR_POS, xpos, ypos };
-  write_cmd((byte*) &msg, sizeof(msg_cursor_pos_t));
+  write_cmd((uint8_t*) &msg, sizeof(msg_cursor_pos_t));
 }
 
 //---------------------------------------------------------
@@ -306,7 +306,7 @@ void send_mouse_button(keymap_t keymap, int button, int action, int mods, float 
     xpos,
     ypos
   };
-  write_cmd((byte*) &msg, sizeof(msg_mouse_button_t));
+  write_cmd((uint8_t*) &msg, sizeof(msg_mouse_button_t));
 }
 
 //---------------------------------------------------------
@@ -322,7 +322,7 @@ PACK(typedef struct msg_scroll_t
 void send_scroll(float xoffset, float yoffset, float xpos, float ypos)
 {
   msg_scroll_t msg = { MSG_OUT_MOUSE_SCROLL, xoffset, yoffset, xpos, ypos };
-  write_cmd((byte*) &msg, sizeof(msg_scroll_t));
+  write_cmd((uint8_t*) &msg, sizeof(msg_scroll_t));
 }
 
 //---------------------------------------------------------
@@ -337,7 +337,7 @@ PACK(typedef struct msg_cursor_enter_t
 void send_cursor_enter(int entered, float xpos, float ypos)
 {
   msg_cursor_enter_t msg = { MSG_OUT_CURSOR_ENTER, entered, xpos, ypos };
-  write_cmd((byte*) &msg, sizeof(msg_cursor_enter_t));
+  write_cmd((uint8_t*) &msg, sizeof(msg_cursor_enter_t));
 }
 
 //---------------------------------------------------------
@@ -350,7 +350,7 @@ PACK(typedef struct msg_close_t
 void send_close( int reason )
 {
   msg_close_t msg = { MSG_OUT_CLOSE, reason };
-  write_cmd((byte*) &msg, sizeof(msg_close_t));
+  write_cmd((uint8_t*) &msg, sizeof(msg_close_t));
 }
 
 //---------------------------------------------------------
@@ -363,14 +363,14 @@ PACK(typedef struct img_miss_t
 void send_image_miss( unsigned int img_id )
 {
   img_miss_t msg = { MSG_OUT_IMG_MISS, img_id };
-  write_cmd((byte*) &msg, sizeof(img_miss_t));
+  write_cmd((uint8_t*) &msg, sizeof(img_miss_t));
 }
 
 //---------------------------------------------------------
 void send_ready()
 {
   uint32_t msg_id = MSG_OUT_READY;
-  write_cmd((byte*) &msg_id, sizeof(msg_id));
+  write_cmd((uint8_t*) &msg_id, sizeof(msg_id));
 }
 
 //=============================================================================
@@ -447,7 +447,7 @@ void update_cursor(uint32_t* p_msg_length, driver_data_t* p_data)
 //---------------------------------------------------------
 void clear_color(uint32_t* p_msg_length)
 {
-  byte r, g, b, a;
+  uint8_t r, g, b, a;
   read_bytes_down(&r, 1, p_msg_length);
   read_bytes_down(&g, 1, p_msg_length);
   read_bytes_down(&b, 1, p_msg_length);

--- a/c_src/scenic/comms.c
+++ b/c_src/scenic/comms.c
@@ -58,7 +58,7 @@ int write_cmd(byte* buf, unsigned int len)
 }
 
 //---------------------------------------------------------
-bool read_bytes_down(void* p_buff, int bytes_to_read, int* p_bytes_to_remaining)
+bool read_bytes_down(void* p_buff, int bytes_to_read, uint32_t* p_bytes_to_remaining)
 {
   if (p_bytes_to_remaining <= 0)
     return false;
@@ -420,7 +420,7 @@ void render(driver_data_t* p_data)
 }
 
 //---------------------------------------------------------
-void set_global_tx(int* p_msg_length, driver_data_t* p_data)
+void set_global_tx(uint32_t* p_msg_length, driver_data_t* p_data)
 {
   for (int i = 0; i < 6; i++) {
     read_bytes_down(&p_data->global_tx[i], sizeof(float), p_msg_length);
@@ -428,7 +428,7 @@ void set_global_tx(int* p_msg_length, driver_data_t* p_data)
 }
 
 //---------------------------------------------------------
-void set_cursor_tx(int* p_msg_length, driver_data_t* p_data)
+void set_cursor_tx(uint32_t* p_msg_length, driver_data_t* p_data)
 {
   for (int i = 0; i < 6; i++) {
     read_bytes_down(&p_data->cursor_tx[i], sizeof(float), p_msg_length);
@@ -436,7 +436,7 @@ void set_cursor_tx(int* p_msg_length, driver_data_t* p_data)
 }
 
 //---------------------------------------------------------
-void update_cursor(int* p_msg_length, driver_data_t* p_data)
+void update_cursor(uint32_t* p_msg_length, driver_data_t* p_data)
 {
   read_bytes_down(&p_data->f_show_cursor, sizeof(uint32_t), p_msg_length);
   for (int i = 0; i < 2; i++) {
@@ -445,7 +445,7 @@ void update_cursor(int* p_msg_length, driver_data_t* p_data)
 }
 
 //---------------------------------------------------------
-void clear_color(int* p_msg_length)
+void clear_color(uint32_t* p_msg_length)
 {
   byte r, g, b, a;
   read_bytes_down(&r, 1, p_msg_length);

--- a/c_src/scenic/comms.h
+++ b/c_src/scenic/comms.h
@@ -94,8 +94,8 @@ typedef enum {
   KEYMAP_GDK = 0x02,
 } keymap_t;
 
-int read_exact(byte* buf, int len);
-int write_exact(byte* buf, int len);
+int read_exact(uint8_t* buf, int len);
+int write_exact(uint8_t* buf, int len);
 int read_msg_length(struct timeval * ptv);
 bool isCallerDown();
 

--- a/c_src/scenic/comms.h
+++ b/c_src/scenic/comms.h
@@ -104,7 +104,7 @@ int read_msg_length(struct timeval * ptv);
 bool isCallerDown();
 
 bool read_bytes_down(void* p_buff, int bytes_to_read,
-                     int* p_bytes_to_remaining);
+                     uint32_t* p_bytes_to_remaining);
 
 // basic events to send up to the caller
 void send_puts(const char* msg, ...);
@@ -124,10 +124,10 @@ void log_info(const char* msg, ...);
 void log_warn(const char* msg, ...);
 void log_error(const char* msg, ...);
 
-void set_global_tx(int* p_msg_length, driver_data_t* p_data);
-void set_cursor_tx(int* p_msg_length, driver_data_t* p_data);
-void update_cursor(int* p_msg_length, driver_data_t* p_data);
-void clear_color(int* p_msg_length);
+void set_global_tx(uint32_t* p_msg_length, driver_data_t* p_data);
+void set_cursor_tx(uint32_t* p_msg_length, driver_data_t* p_data);
+void update_cursor(uint32_t* p_msg_length, driver_data_t* p_data);
+void clear_color(uint32_t* p_msg_length);
 void receive_crash();
 void receive_quit(driver_data_t* p_data);
 void render(driver_data_t* p_data);

--- a/c_src/scenic/comms.h
+++ b/c_src/scenic/comms.h
@@ -87,15 +87,11 @@ typedef enum {
   MSG_OUT_WARN = 0XA1,
   MSG_OUT_ERROR = 0XA2,
   MSG_OUT_DEBUG = 0XA3,
-
-  _MSG_OUT_SIZE_ = 0XFFFFFFFF,
 } msg_out_t;
 
 typedef enum {
   KEYMAP_GLFW = 0x01,
   KEYMAP_GDK = 0x02,
-
-  _KEYMAP_SIZE_ = 0xFFFFFFFF,
 } keymap_t;
 
 int read_exact(byte* buf, int len);

--- a/c_src/scenic/scenic_ops.c
+++ b/c_src/scenic/scenic_ops.c
@@ -110,7 +110,7 @@ void scenic_ops_crash()
   receive_crash();
 }
 
-void dispatch_scenic_ops(int msg_length, driver_data_t* p_data)
+void dispatch_scenic_ops(uint32_t msg_length, driver_data_t* p_data)
 {
   scenic_op_t op;
   read_bytes_down(&op, sizeof(uint32_t), &msg_length);

--- a/c_src/scenic/scenic_ops.h
+++ b/c_src/scenic/scenic_ops.h
@@ -54,4 +54,4 @@ void scenic_ops_put_font(uint32_t* p_msg_length, driver_data_t* p_data);
 void scenic_ops_put_image(uint32_t* p_msg_length, driver_data_t* p_data);
 void scenic_ops_crash();
 
-void dispatch_scenic_ops(int msg_length, driver_data_t* p_data);
+void dispatch_scenic_ops(uint32_t msg_length, driver_data_t* p_data);

--- a/c_src/scenic/scenic_ops.h
+++ b/c_src/scenic/scenic_ops.h
@@ -49,9 +49,10 @@ void scenic_ops_cursor_tx(uint32_t* p_msg_length, driver_data_t* p_data);
 void scenic_ops_render(uint32_t* p_msg_length, driver_data_t* p_data);
 void scenic_ops_update_cursor(uint32_t* p_msg_length, driver_data_t* p_data);
 void scenic_ops_clear_color(uint32_t* p_msg_length, const driver_data_t* p_data);
-void scenic_ops_quit(driver_data_t* data);
+void scenic_ops_quit(driver_data_t* p_data);
 void scenic_ops_put_font(uint32_t* p_msg_length, driver_data_t* p_data);
 void scenic_ops_put_image(uint32_t* p_msg_length, driver_data_t* p_data);
 void scenic_ops_crash();
 
 void dispatch_scenic_ops(uint32_t msg_length, driver_data_t* p_data);
+void* scenic_loop(void* user_data);

--- a/c_src/scenic/scenic_types.h
+++ b/c_src/scenic/scenic_types.h
@@ -23,8 +23,6 @@
   #endif
 #endif
 
-typedef unsigned char byte;
-
 //---------------------------------------------------------
 PACK(typedef struct Vector2f
 {

--- a/c_src/scenic/script.c
+++ b/c_src/scenic/script.c
@@ -76,7 +76,7 @@ void do_delete_script(sid_t id)
 }
 
 //---------------------------------------------------------
-void put_script(int* p_msg_length)
+void put_script(uint32_t* p_msg_length)
 {
   // read in the length of the id, which is in the first four bytes
   uint32_t id_length;
@@ -118,7 +118,7 @@ void put_script(int* p_msg_length)
 }
 
 //---------------------------------------------------------
-void delete_script(int* p_msg_length)
+void delete_script(uint32_t* p_msg_length)
 {
   sid_t id;
 
@@ -157,30 +157,35 @@ void reset_scripts() {
 //=============================================================================
 // rendering
 
-static inline byte get_byte( void* p, uint32_t offset ) {
+static inline byte get_byte(void* p, uint32_t offset)
+{
   return *((byte*)(p + offset));
 }
 
-static inline unsigned short get_uint16( void* p, uint32_t offset ) {
+static inline unsigned short get_uint16(void* p, uint32_t offset)
+{
   return ntoh_ui16(*((unsigned short*)(p + offset)));
 }
 
-static inline unsigned int get_uint32( void* p, uint32_t offset ) {
+static inline unsigned int get_uint32(void* p, uint32_t offset)
+{
   return ntoh_ui32(*((unsigned int*)(p + offset)));
 }
 
-static inline float get_float( void* p, uint32_t offset ) {
+static inline float get_float(void* p, uint32_t offset)
+{
   return ntoh_f32(*((float*)(p + offset)));
 }
 
 
-int padded_advance( int size ) {
+int padded_advance(int size)
+{
   switch( size % 4 ) {
     case 0: return size;
     case 1: return size + 3;
     case 2: return size + 2;
     case 3: return size + 1;
-    default: size;
+    default: return size;
   };
 }
 

--- a/c_src/scenic/script.c
+++ b/c_src/scenic/script.c
@@ -157,19 +157,19 @@ void reset_scripts() {
 //=============================================================================
 // rendering
 
-static inline byte get_byte(void* p, uint32_t offset)
+static inline uint8_t get_byte(void* p, uint32_t offset)
 {
-  return *((byte*)(p + offset));
+  return *((uint8_t*)(p + offset));
 }
 
-static inline unsigned short get_uint16(void* p, uint32_t offset)
+static inline uint16_t get_uint16(void* p, uint32_t offset)
 {
-  return ntoh_ui16(*((unsigned short*)(p + offset)));
+  return ntoh_ui16(*((uint16_t*)(p + offset)));
 }
 
-static inline unsigned int get_uint32(void* p, uint32_t offset)
+static inline uint32_t get_uint32(void* p, uint32_t offset)
 {
-  return ntoh_ui32(*((unsigned int*)(p + offset)));
+  return ntoh_ui32(*((uint32_t*)(p + offset)));
 }
 
 static inline float get_float(void* p, uint32_t offset)

--- a/c_src/scenic/script.h
+++ b/c_src/scenic/script.h
@@ -11,8 +11,8 @@
 
 void init_scripts(void);
 
-void put_script(int* p_msg_length);
-void delete_script(int* p_msg_length);
+void put_script(uint32_t* p_msg_length);
+void delete_script(uint32_t* p_msg_length);
 
 void reset_scripts();
 void render_script(void* v_ctx, sid_t id);

--- a/c_src/scenic/script.h
+++ b/c_src/scenic/script.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "scenic_types.h"
-#include "tommyds/src/tommyhashlin.h"
 
 void init_scripts(void);
 

--- a/c_src/scenic/script_ops.h
+++ b/c_src/scenic/script_ops.h
@@ -130,7 +130,7 @@ typedef enum {
 
 #define SCRIPT_FUNC(name, args...) \
   void script_ops_ ## name(void* v_ctx, ##args); \
-  void log_script_ops_ ## name(const char* prefix, const char* func, log_level_t level, ##args);
+  void log_script_ops_ ## name(const char* prefix, const char* func, log_level_t level, ##args)
 
 SCRIPT_FUNC(draw_line, coordinates_t a, coordinates_t b, bool stroke);
 SCRIPT_FUNC(draw_triangle, coordinates_t a, coordinates_t b, coordinates_t c, bool fill, bool stroke);

--- a/c_src/scenic/unix_comms.c
+++ b/c_src/scenic/unix_comms.c
@@ -5,7 +5,7 @@
 // from erl_comm.c
 // http://erlang.org/doc/tutorial/c_port.html#id64377
 //---------------------------------------------------------
-int read_exact(byte* buf, int len)
+int read_exact(uint8_t* buf, int len)
 {
   int i, got = 0;
 
@@ -20,7 +20,7 @@ int read_exact(byte* buf, int len)
 }
 
 //---------------------------------------------------------
-int write_exact(byte* buf, int len)
+int write_exact(uint8_t* buf, int len)
 {
   int i, wrote = 0;
 
@@ -43,7 +43,7 @@ int write_exact(byte* buf, int len)
 // frame rate
 int read_msg_length(struct timeval * ptv)
 {
-  byte buff[4];
+  uint8_t buff[4];
 
   fd_set rfds;
   int    retval;

--- a/lib/from_port.ex
+++ b/lib/from_port.ex
@@ -145,7 +145,7 @@ defmodule Scenic.Driver.Local.FromPort do
         <<@msg_warn_id::unsigned-integer-size(32)-native>> <> msg,
         driver
       ) do
-    Logger.warn("scenic_driver_local: #{msg}")
+    Logger.warning("scenic_driver_local: #{msg}")
     {:noreply, driver}
   end
 

--- a/lib/mix/tasks/compile.local.ex
+++ b/lib/mix/tasks/compile.local.ex
@@ -20,39 +20,11 @@ defmodule Mix.Tasks.Compile.ScenicDriverLocal do
     # tell elixir_make which C target to build by setting a sys env var
     with nil <- System.get_env("SCENIC_LOCAL_TARGET") do
       case target() do
-        :dev ->
-          System.put_env("SCENIC_LOCAL_TARGET", "glfw")
-
-        :host ->
-          System.put_env("SCENIC_LOCAL_TARGET", "glfw")
-
-        :rpi ->
-          System.put_env("SCENIC_LOCAL_TARGET", "bcm")
-
-        :rpi0 ->
-          System.put_env("SCENIC_LOCAL_TARGET", "bcm")
-
-        :rpi2 ->
-          System.put_env("SCENIC_LOCAL_TARGET", "bcm")
-
-        :rpi3 ->
-          System.put_env("SCENIC_LOCAL_TARGET", "bcm")
-
-        :rpi3a ->
-          System.put_env("SCENIC_LOCAL_TARGET", "bcm")
-
-        :bbb ->
-          System.put_env("SCENIC_LOCAL_TARGET", "drm")
-          System.put_env("SCENIC_LOCAL_GL", "gles2")
-
-        :rpi4 ->
-          System.put_env("SCENIC_LOCAL_TARGET", "drm")
-          System.put_env("SCENIC_LOCAL_GL", "gles3")
+        n when n in [:dev, :host] ->
+          System.put_env("SCENIC_LOCAL_TARGET", "cairo-gtk")
 
         _ ->
-          # let it go without specifying anything.
-          # The Makefile will put up an appropriate error
-          :ok
+          System.put_env("SCENIC_LOCAL_TARGET", "cairo-fb")
       end
     end
 

--- a/lib/to_port.ex
+++ b/lib/to_port.ex
@@ -6,7 +6,7 @@
 defmodule Scenic.Driver.Local.ToPort do
   @moduledoc false
 
-  use Bitwise
+  import Bitwise
 
   @cmd_put_script 0x01
   @cmd_del_script 0x02


### PR DESCRIPTION
This PR is on top https://github.com/ScenicFramework/scenic_driver_local/pull/53 and https://github.com/ScenicFramework/scenic_driver_local/pull/54

Default SCENIC_LOCAL_TARGET to `cairo-gtk` for host and `cairo-fb` for targets.
Deprecate `glfw`, `drm`, and `bcm`. User still has the option to select these explicitly with `SCENIC_LOCAL_TARGET=`