### PR TITLE
Allow opacity & layer (above/below) to be set in viewport config

### DIFF
--- a/c_src/device/cairo/cairo_gtk.c
+++ b/c_src/device/cairo/cairo_gtk.c
@@ -279,5 +279,16 @@ void device_loop(driver_data_t* p_data)
   g_set_printerr_handler(glib_error);
 
   gtk_widget_show_all((GtkWidget*)g_cairo_gtk.window);
+
+  gtk_widget_set_opacity(GTK_WIDGET(g_cairo_gtk.window), (g_opts.global_opacity / 255.0f));
+
+  if (g_opts.layer > 0) {
+    gtk_window_set_keep_above(GTK_WINDOW(g_cairo_gtk.window), TRUE);
+  }
+
+  if (g_opts.layer < 0) {
+    gtk_window_set_keep_below(GTK_WINDOW(g_cairo_gtk.window), TRUE);
+  }
+
   gtk_main();
 }

--- a/c_src/device/cairo/cairo_gtk.c
+++ b/c_src/device/cairo/cairo_gtk.c
@@ -132,8 +132,16 @@ static gboolean on_scroll_event(GtkWidget* widget,
 {
   float x = floorf(event->x);
   float y = floorf(event->y);
-  float xoffset = floorf(event->delta_x);
-  float yoffset = floorf(event->delta_y);
+  float xoffset = 0.0;
+  float yoffset = 0.0;
+
+  switch (event->direction) {
+  case GDK_SCROLL_UP:    yoffset = -1.0; break;
+  case GDK_SCROLL_DOWN:  yoffset = 1.0; break;
+  case GDK_SCROLL_LEFT:  xoffset = 1.0; break;
+  case GDK_SCROLL_RIGHT: xoffset = -1.0; break;
+  case GDK_SCROLL_SMOOTH: return FALSE;
+  }
   send_scroll(xoffset, yoffset, x, y);
 
   return TRUE;


### PR DESCRIPTION
This PR is on top of #57 

I had a request from a user who had hacked the glfw driver to make his window transparent and floating. His motivation was that it gave him a great experience using `scenic_live_reload` where he could see his code and the changes load automatically with the scenic window hovering over his code.

This change allows the cairo-gtk to provide the same feature in a supported way by setting the `:opacity` and `:layer` viewport config options