### PR TITLE
Save text align/base context

### DIFF
--- a/c_src/device/cairo/cairo_common.c
+++ b/c_src/device/cairo/cairo_common.c
@@ -75,6 +75,8 @@ void pattern_stack_push(scenic_cairo_ctx_t* p_ctx)
   pattern_stack_t* ptr = (pattern_stack_t*)malloc(sizeof(pattern_stack_t));
 
   ptr->pattern = p_ctx->pattern;
+  ptr->text_align = p_ctx->text_align;
+  ptr->text_base = p_ctx->text_base;
 
   if (!p_ctx->pattern_stack_head) {
     ptr->next = NULL;
@@ -93,6 +95,8 @@ void pattern_stack_pop(scenic_cairo_ctx_t* p_ctx)
     log_error("pattern stack underflow");
   } else {
     p_ctx->pattern = ptr->pattern;
+    p_ctx->text_align = ptr->text_align;
+    p_ctx->text_base = ptr->text_base;
     p_ctx->pattern_stack_head = p_ctx->pattern_stack_head->next;
     free(ptr);
   }

--- a/c_src/device/cairo/cairo_ctx.h
+++ b/c_src/device/cairo/cairo_ctx.h
@@ -12,6 +12,8 @@ typedef struct {
 
 typedef struct pattern_stack_t_ {
   fill_stroke_pattern_t pattern;
+  text_align_t text_align;
+  text_base_t text_base;
   struct pattern_stack_t_* next;
 } pattern_stack_t;
 

--- a/c_src/device/cairo/cairo_script_ops.c
+++ b/c_src/device/cairo/cairo_script_ops.c
@@ -288,6 +288,7 @@ void script_ops_draw_text(void* v_ctx,
     break;
   }
 
+  cairo_save(p_ctx->cr);
   cairo_translate(p_ctx->cr, align_offset, base_offset);
   cairo_set_source(p_ctx->cr, p_ctx->pattern.fill);
 
@@ -307,9 +308,7 @@ void script_ops_draw_text(void* v_ctx,
   } else {
     log_error("%s: cairo_scaled_font_text_to_glyphs: error %d", __func__, status);
   }
-
-  p_ctx->text_align = TEXT_ALIGN_LEFT;
-  p_ctx->text_base = TEXT_BASE_ALPHABETIC;
+  cairo_restore(p_ctx->cr);
 }
 
 static void draw_sprite(scenic_cairo_ctx_t* p_ctx,


### PR DESCRIPTION
This fixes text alignment issues with multiple text lines using the same text align/base