### PR TITLE
Jringle/fps debug

### DIFF
--- a/c_src/main.c
+++ b/c_src/main.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
   driver_data_t data = {0};
 
   // super simple arg check
-  if (argc != 10) {
+  if (argc != 11) {
     log_error("Wrong number of parameters");
     return -1;
   }
@@ -41,10 +41,11 @@ int main(int argc, char **argv)
   g_opts.global_opacity = atoi(argv[3]);
   g_opts.antialias = atoi(argv[4]);
   g_opts.debug_mode = atoi(argv[5]);
-  g_opts.width = atoi(argv[6]);
-  g_opts.height = atoi(argv[7]);
-  g_opts.resizable = atoi(argv[8]);
-  g_opts.title = argv[9];
+  g_opts.debug_fps = atoi(argv[6]);
+  g_opts.width = atoi(argv[7]);
+  g_opts.height = atoi(argv[8]);
+  g_opts.resizable = atoi(argv[9]);
+  g_opts.title = argv[10];
 
   // init the hashtables
   init_scripts();

--- a/c_src/scenic/comms.c
+++ b/c_src/scenic/comms.c
@@ -21,19 +21,11 @@ The caller will typically be erlang, so use the 2-byte length indicator
 #include "script.h"
 #include "utils.h"
 
-// handy time definitions in microseconds
-#define MILLISECONDS_8 8000
-#define MILLISECONDS_16 16000
-#define MILLISECONDS_20 20000
-#define MILLISECONDS_32 32000
-#define MILLISECONDS_64 64000
-#define MILLISECONDS_128 128000
-
 // Setting the timeout too high means input will be laggy as you
 // are starving the input polling. Setting it too low means using
 // energy for no purpose. Probably best if set similar to the
 // frame rate of the application
-#define STDIO_TIMEOUT MILLISECONDS_32
+#define STDIO_TIMEOUT 32
 
 extern device_info_t g_device_info;
 

--- a/c_src/scenic/comms.c
+++ b/c_src/scenic/comms.c
@@ -28,6 +28,7 @@ The caller will typically be erlang, so use the 2-byte length indicator
 #define STDIO_TIMEOUT 32
 
 extern device_info_t g_device_info;
+extern device_opts_t g_opts;
 
 //=============================================================================
 // raw comms with host app
@@ -431,9 +432,9 @@ void render(driver_data_t* p_data)
   clock_t end_frame = clock();
   clock_t delta_ticks = end_frame - begin_frame;
 
-  if (delta_ticks > 0) {
+  if ((g_opts.debug_fps > 1) && (delta_ticks > 0)) {
     render_fps = CLOCKS_PER_SEC / delta_ticks;
-    // log_debug("render_fps (cpu time): %d", render_fps);
+    log_debug("render_fps (cpu time): %d", render_fps);
   }
 
   frames++;
@@ -443,8 +444,8 @@ void render(driver_data_t* p_data)
   start_real = end_real;
   time_remaining -= delta_real;
 
-  if (time_remaining <= 0) {
-    log_debug("real_fps: %d", frames);
+  if ((g_opts.debug_fps > 0) && (time_remaining <= 0)) {
+    log_info("real_fps: %d", frames);
     start_real = monotonic_time();
     time_remaining = 1000;
     frames = 0;

--- a/c_src/scenic/scenic_types.h
+++ b/c_src/scenic/scenic_types.h
@@ -61,6 +61,7 @@ typedef struct {
 typedef struct {
   // options from the command line
   int debug_mode;
+  int debug_fps;
   int layer;
   int global_opacity;
   int antialias;

--- a/lib/driver.ex
+++ b/lib/driver.ex
@@ -26,6 +26,7 @@ defmodule Scenic.Driver.Local do
     opacity: [type: :integer, default: @default_opacity],
     debug: [type: :boolean, default: false],
     debugger: [type: :string, default: ""],
+    debug_fps: [type: :integer, default: 0],
     antialias: [type: :boolean, default: true],
     calibration: [
       type: {:custom, __MODULE__, :validate_calibration, []},
@@ -214,6 +215,7 @@ defmodule Scenic.Driver.Local do
       end
 
     {:ok, debugger} = Keyword.fetch(opts, :debugger)
+    {:ok, debug_fps} = Keyword.fetch(opts, :debug_fps)
     {:ok, layer} = Keyword.fetch(opts, :layer)
     {:ok, opacity} = Keyword.fetch(opts, :opacity)
 
@@ -227,7 +229,7 @@ defmodule Scenic.Driver.Local do
       end
 
     args =
-      " #{internal_cursor} #{layer} #{opacity} #{antialias} #{debug_mode}" <>
+      " #{internal_cursor} #{layer} #{opacity} #{antialias} #{debug_mode} #{debug_fps}" <>
         " #{width} #{height} #{resizeable} \"#{title}\""
 
     # open and initialize the window

--- a/test/driver_test.exs
+++ b/test/driver_test.exs
@@ -9,6 +9,7 @@ defmodule Scenic.Driver.LocalTest do
       opacity: 1,
       debug: false,
       debugger: "",
+      debug_fps: 0,
       antialias: true,
       calibration: [{"calibration_name", {{0, 0, 0}, {0, 0, 0}}}],
       position: [


### PR DESCRIPTION
@axelson This will log every second the number of frames rendered.
Could you run this against the code you are having issues with?
Also with `SCENIC_DRIVER_LOCAL=glfw` for comparison against the non-cairo code on host,
and `SCENIC_DRIVER_LOCAL=drm` for comparison against the non-cairo code on rpi3

On the application config for the viewport set the `debug_fps` option to 1 or 2 to get debug fps output:
```elixir
config :hello_scenic_full, :viewport,
  name: :main_viewport,
  size: {800, 600},
  theme: :dark,
  default_scene: HelloScenicFull.Scene.Components,
  drivers: [
    [
      module: Scenic.Driver.Local,
      name: :local,
      window: [resizeable: false, title: "hello_scenic_full"],
      on_close: :stop_system,
      debug_fps: 2,
      layer: 1,
      opacity: 180,
    ]
  ]
```