### PR TITLE
Make framebuffer device used by `cairo-fb` configurable.

### DIFF
--- a/c_src/device/cairo/cairo_fb.c
+++ b/c_src/device/cairo/cairo_fb.c
@@ -17,7 +17,6 @@
 #include "scenic_ops.h"
 
 #define FB0_TIMEOUT 60 //seconds
-const char* device = "/dev/fb0";
 
 typedef struct {
   int fd;
@@ -100,14 +99,14 @@ int device_init(const device_opts_t* p_opts,
 
   time_t fb0_timer_start = time(NULL);
   while ((time(NULL) - fb0_timer_start) < FB0_TIMEOUT) {
-    if ((g_cairo_fb.fd = open(device, O_RDWR)) != -1) {
+    if ((g_cairo_fb.fd = open(g_opts.fbdev, O_RDWR)) != -1) {
       break;
     }
     sched_yield();
   }
 
   if (g_cairo_fb.fd == -1) {
-    log_error("Failed to open device %s: %s", device, strerror(errno));
+    log_error("Failed to open device %s: %s", g_opts.fbdev, strerror(errno));
     return -1;
   }
 

--- a/c_src/main.c
+++ b/c_src/main.c
@@ -45,7 +45,8 @@ int main(int argc, char **argv)
   g_opts.width = atoi(argv[7]);
   g_opts.height = atoi(argv[8]);
   g_opts.resizable = atoi(argv[9]);
-  g_opts.title = argv[10];
+  g_opts.fbdev = argv[10];
+  g_opts.title = argv[11];
 
   // init the hashtables
   init_scripts();

--- a/c_src/scenic/scenic_types.h
+++ b/c_src/scenic/scenic_types.h
@@ -69,6 +69,7 @@ typedef struct {
   int width;
   int height;
   int resizable;
+  char* fbdev;
   char* title;
 } device_opts_t;
 

--- a/lib/driver.ex
+++ b/lib/driver.ex
@@ -70,7 +70,7 @@ defmodule Scenic.Driver.Local do
   alias Scenic.Math.Matrix
   alias Scenic.Math.Vector2
 
-  @port '/scenic_driver_local'
+  @port ~c"/scenic_driver_local"
 
   # @root_id Scenic.ViewPort.root_id()
 
@@ -148,7 +148,7 @@ defmodule Scenic.Driver.Local do
   end
 
   # not ready to expose these yet. I want to think through the cursor model better
-  # it will probably end up as a :cursor style that you can place on items. Then the 
+  # it will probably end up as a :cursor style that you can place on items. Then the
   # cursor type would change as it moves over those items.
 
   # the reason I'm not exposing this now is that it would require the :cursor_pos
@@ -221,6 +221,7 @@ defmodule Scenic.Driver.Local do
 
     {:ok, window_opts} = Keyword.fetch(opts, :window)
     {:ok, title} = Keyword.fetch(window_opts, :title)
+    fbdev = Keyword.get(window_opts, :fbdev, "/dev/fb0")
 
     resizeable =
       case window_opts[:resizeable] do
@@ -230,14 +231,14 @@ defmodule Scenic.Driver.Local do
 
     args =
       " #{internal_cursor} #{layer} #{opacity} #{antialias} #{debug_mode} #{debug_fps}" <>
-        " #{width} #{height} #{resizeable} \"#{title}\""
+        " #{width} #{height} #{resizeable} #{fbdev} \"#{title}\""
 
     # open and initialize the window
     Process.flag(:trap_exit, true)
 
     executable =
       to_charlist(debugger) ++
-        ' ' ++ :code.priv_dir(:scenic_driver_local) ++ @port ++ to_charlist(args)
+        ~c" " ++ :code.priv_dir(:scenic_driver_local) ++ @port ++ to_charlist(args)
 
     port = Port.open({:spawn, executable}, [:binary, {:packet, 4}])
 


### PR DESCRIPTION
As described in #68 - attempt to make the framebuffer device used by cairo-fb configurable.